### PR TITLE
Add product delivery types to navigation and use case messaging

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,7 +5,24 @@
 <header class="header"><div class="container nav">
   <a class="brand" href="/"><span class="dot"></span>StudioOrganize</a>
   <nav class="menu">
-    <a href="/products/">Products</a><a href="/faq.html">FAQ</a><a class="active" href="/about.html">About</a>
+    <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
+    <div class="dropdown">
+      <button class="dropbtn">Use Cases</button>
+      <div class="dropdown-content">
+        <a href="/use-cases/">All Use Cases</a>
+        <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
+        <a href="/use-cases/screenplay.html">Screenplay Script</a>
+        <a href="/use-cases/character-design.html">Character Design</a>
+        <a href="/use-cases/set-design.html">Set / Production Design</a>
+      </div>
+    </div>
+    <a href="/faq.html">FAQ</a><a class="active" href="/about.html">About</a>
     <a class="cta" href="mailto:hello@studioorganize.com">Contact</a>
   </nav>
 </div></header>

--- a/faq.html
+++ b/faq.html
@@ -5,7 +5,24 @@
 <header class="header"><div class="container nav">
   <a class="brand" href="/"><span class="dot"></span>StudioOrganize</a>
   <nav class="menu">
-    <a href="/products/">Products</a><a class="active" href="/faq.html">FAQ</a><a href="/about.html">About</a>
+    <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
+    <div class="dropdown">
+      <button class="dropbtn">Use Cases</button>
+      <div class="dropdown-content">
+        <a href="/use-cases/">All Use Cases</a>
+        <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
+        <a href="/use-cases/screenplay.html">Screenplay Script</a>
+        <a href="/use-cases/character-design.html">Character Design</a>
+        <a href="/use-cases/set-design.html">Set / Production Design</a>
+      </div>
+    </div>
+    <a class="active" href="/faq.html">FAQ</a><a href="/about.html">About</a>
     <a class="cta" href="mailto:hello@studioorganize.com">Contact</a>
   </nav>
 </div></header>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,13 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
-    <a href="/products/">Products</a>
+    <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
 
     <div class="dropdown">
       <button class="dropbtn">Use Cases</button>

--- a/product/1week-story
+++ b/product/1week-story
@@ -10,7 +10,13 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
-    <a href="/products/">Products</a>
+    <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
 
     <div class="dropdown">
       <button class="dropbtn">Use Cases</button>

--- a/product/personal.html
+++ b/product/personal.html
@@ -9,7 +9,26 @@
 <body>
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
-  <nav><a href="/products/">Products</a><a href="/faq.html">FAQ</a></nav>
+  <nav class="menu">
+    <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
+    <div class="dropdown">
+      <button class="dropbtn">Use Cases</button>
+      <div class="dropdown-content">
+        <a href="/use-cases/">All Use Cases</a>
+        <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
+        <a href="/use-cases/screenplay.html">Screenplay Script</a>
+        <a href="/use-cases/character-design.html">Character Design</a>
+        <a href="/use-cases/set-design.html">Set / Production Design</a>
+      </div>
+    </div>
+    <a href="/faq.html">FAQ</a>
+  </nav>
 </header>
 
 <main class="section">

--- a/product/studioorganize.html
+++ b/product/studioorganize.html
@@ -10,7 +10,13 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
-    <a href="/products/">Products</a>
+    <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
 
     <div class="dropdown">
       <button class="dropbtn">Use Cases</button>

--- a/product/template.html
+++ b/product/template.html
@@ -7,7 +7,24 @@
 <header class="header"><div class="container nav">
   <a class="brand" href="/"><span class="dot"></span>StudioOrganize</a>
   <nav class="menu">
-    <a href="/products/">Products</a><a href="/faq.html">FAQ</a><a href="/about.html">About</a>
+    <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
+    <div class="dropdown">
+      <button class="dropbtn">Use Cases</button>
+      <div class="dropdown-content">
+        <a href="/use-cases/">All Use Cases</a>
+        <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
+        <a href="/use-cases/screenplay.html">Screenplay Script</a>
+        <a href="/use-cases/character-design.html">Character Design</a>
+        <a href="/use-cases/set-design.html">Set / Production Design</a>
+      </div>
+    </div>
+    <a href="/faq.html">FAQ</a><a href="/about.html">About</a>
     <a class="cta" href="mailto:hello@studioorganize.com">Contact</a>
   </nav>
 </div></header>

--- a/products/index.html
+++ b/products/index.html
@@ -13,6 +13,14 @@
     <a href="/">Home</a>
 
     <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
+
+    <div class="dropdown">
       <button class="dropbtn">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
@@ -30,6 +38,24 @@
 
 <main class="section">
   <h1>Products</h1>
+
+  <section class="section alt" style="margin-top:0">
+    <h2>Choose how you want to work</h2>
+    <div class="grid cards">
+      <div class="card card--lg" id="online">
+        <h3>Subscribe &amp; save it online</h3>
+        <p>Use the hosted StudioOrganize workspace with automatic backups, real-time collaboration, and zero setup.</p>
+        <p class="muted">Perfect if you want everything managed for you. Join the waitlist and we’ll email you when subscriptions open.</p>
+        <a class="arrow" href="mailto:support@studioorganize.com?subject=StudioOrganize%20Online%20Waitlist">Join the waitlist →</a>
+      </div>
+      <div class="card card--lg" id="sheets">
+        <h3>Google Sheets — keep the database yourself</h3>
+        <p>Download the full toolkit as Google Sheets and Apps Script files so you own the data and control every copy.</p>
+        <p class="muted">Best if you love tinkering, want lifetime access, and prefer storing projects inside your own Drive.</p>
+        <a class="arrow" href="/product/studioorganize.html">Browse the spreadsheet suite →</a>
+      </div>
+    </div>
+  </section>
 
   <h2>🎬 Creative Tools</h2>
   <div class="grid cards">

--- a/products/personal.html
+++ b/products/personal.html
@@ -5,7 +5,24 @@
 <header class="header"><div class="container nav">
   <a class="brand" href="/"><span class="dot"></span>StudioOrganize</a>
   <nav class="menu">
-    <a class="active" href="/products/">Products</a><a href="/faq.html">FAQ</a><a href="/about.html">About</a>
+    <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
+    <div class="dropdown">
+      <button class="dropbtn">Use Cases</button>
+      <div class="dropdown-content">
+        <a href="/use-cases/">All Use Cases</a>
+        <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
+        <a href="/use-cases/screenplay.html">Screenplay Script</a>
+        <a href="/use-cases/character-design.html">Character Design</a>
+        <a href="/use-cases/set-design.html">Set / Production Design</a>
+      </div>
+    </div>
+    <a href="/faq.html">FAQ</a><a href="/about.html">About</a>
     <a class="cta" href="mailto:hello@studioorganize.com">Contact</a>
   </nav>
 </div></header>

--- a/use-cases/character-design.html
+++ b/use-cases/character-design.html
@@ -10,7 +10,13 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
-    <a href="/products/">Products</a>
+    <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
     <div class="dropdown">
       <button class="dropbtn">Use Cases</button>
       <div class="dropdown-content">

--- a/use-cases/generate-ideas.html
+++ b/use-cases/generate-ideas.html
@@ -11,7 +11,13 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
-    <a href="/products/">Products</a>
+    <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
     <div class="dropdown">
       <button class="dropbtn">Use Cases</button>
       <div class="dropdown-content">

--- a/use-cases/index.html
+++ b/use-cases/index.html
@@ -11,7 +11,13 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
-    <a href="/products/">Products</a>
+    <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
     <div class="dropdown">
       <button class="dropbtn">Use Cases</button>
       <div class="dropdown-content">
@@ -30,6 +36,7 @@
 <div class="hero-mini">
   <h1>Use Cases</h1>
   <p class="muted">Practical, show-by-doing guides that use the StudioOrganize Spreadsheet as the engine.</p>
+  <p class="muted">Each category is a polished mini app of its own — like the Script Writer feature, a standalone program that helps you craft a full screenplay.</p>
 </div>
 
 <main class="section">

--- a/use-cases/screenplay.html
+++ b/use-cases/screenplay.html
@@ -10,7 +10,13 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
-    <a href="/products/">Products</a>
+    <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
     <div class="dropdown">
       <button class="dropbtn">Use Cases</button>
       <div class="dropdown-content">

--- a/use-cases/set-design.html
+++ b/use-cases/set-design.html
@@ -10,7 +10,13 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
-    <a href="/products/">Products</a>
+    <div class="dropdown">
+      <button class="dropbtn">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
     <div class="dropdown">
       <button class="dropbtn">Use Cases</button>
       <div class="dropdown-content">


### PR DESCRIPTION
## Summary
- update site navigation to highlight both the hosted subscription and Google Sheets product options
- introduce a products landing section that explains each delivery type with anchors, waitlist CTA, and spreadsheet link
- clarify use case cards as standalone mini programs with a Script Writer example

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab8f420a8832dbbda9e2975d9464f