### PR TITLE
Add blank screenplay writing page and update CTA

### DIFF
--- a/use-cases/screenplay-writing.html
+++ b/use-cases/screenplay-writing.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Screenplay Writing — StudioOrganize</title>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+</head>
+<body>
+  <header class="nav">
+    <a class="brand" href="/">StudioOrganize</a>
+    <nav class="menu">
+      <div class="dropdown">
+        <button class="dropbtn">Products</button>
+        <div class="dropdown-content">
+          <a href="/products/#online">Subscribe &amp; save it online</a>
+          <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+        </div>
+      </div>
+      <div class="dropdown">
+        <button class="dropbtn">Use Cases</button>
+        <div class="dropdown-content">
+          <a href="/use-cases/">All Use Cases</a>
+          <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
+          <a href="/use-cases/screenplay.html">Screenplay Script</a>
+          <a href="/use-cases/character-design.html">Character Design</a>
+          <a href="/use-cases/set-design.html">Set / Production Design</a>
+        </div>
+      </div>
+      <a href="/about.html">About</a>
+      <a href="/faq.html">FAQ</a>
+    </nav>
+  </header>
+
+  <main class="section">
+  </main>
+
+  <footer class="footer">
+    <div class="footer__grid">
+      <div><strong>StudioOrganize</strong></div>
+      <div><a href="/products/">Products</a></div>
+      <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
+    </div>
+  </footer>
+  <script src="/assets/main.js"></script>
+</body>
+</html>

--- a/use-cases/screenplay.html
+++ b/use-cases/screenplay.html
@@ -64,7 +64,7 @@
         <img src="/assets/img/studioorganize_mock.png" alt="Screenplay workflow mockup">
       </div>
       <div class="callout" style="margin-top:12px">
-        <a class="btn btn-primary" href="/product/studioorganize.html">Use this workflow →</a>
+        <a class="btn btn-primary" href="/use-cases/screenplay-writing.html">start writing →</a>
       </div>
     </aside>
   </div>


### PR DESCRIPTION
## Summary
- change the Screenplay workflow call-to-action to read "start writing" and link to a new page
- add a blank Screenplay Writing page that keeps the standard site navigation ready for future content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dabb8f99b0832da3d05aeabaa32941