### PR TITLE
Fix mirrored typing in screenplay editor

### DIFF
--- a/use-cases/screenplay-writing.html
+++ b/use-cases/screenplay-writing.html
@@ -582,16 +582,19 @@
       const editor = document.getElementById('editor');
       const children = Array.from(editor.childNodes);
       const normalized = [];
+      let changed = false;
+
       for (let n of children){
-        if (n.nodeType === 3){ // text
-          const txt = n.textContent.trim();
+        if (n.nodeType === 3){ // text node
           const div = document.createElement('div');
           div.className = 'line action';
           div.dataset.t = 'action';
-          div.textContent = txt;
+          div.textContent = (n.textContent || '').trim();
           normalized.push(div);
+          changed = true;
         } else if (n.nodeType === 1){ // element
           if (n.classList.contains('line')) {
+            if (!n.dataset.t) n.dataset.t = 'action';
             normalized.push(n);
           } else if (n.tagName === 'BR') {
             const div = document.createElement('div');
@@ -599,15 +602,20 @@
             div.dataset.t = 'action';
             div.textContent = '';
             normalized.push(div);
+            changed = true;
           } else {
             const div = document.createElement('div');
             div.className = 'line action';
             div.dataset.t = 'action';
             div.textContent = n.textContent || '';
             normalized.push(div);
+            changed = true;
           }
         }
       }
+
+      if (!changed && normalized.length === children.length) return;
+
       editor.innerHTML = '';
       normalized.forEach(d=>editor.appendChild(d));
     }


### PR DESCRIPTION
## Summary
- avoid rebuilding the editor DOM when it already contains normalized `.line` elements so the caret stays in place
- preserve caret position by only normalizing when structural fixes are needed, fixing reversed typing in the screenplay editor

## Testing
- python -m http.server 8000 (manual)


------
https://chatgpt.com/codex/tasks/task_e_68dafc80a510832da6be0d68d5480d3e