### PR TITLE
Hide navigation chrome during focus mode

### DIFF
--- a/use-cases/screenplay-writing.html
+++ b/use-cases/screenplay-writing.html
@@ -127,6 +127,24 @@
       .line.active{ background: rgba(255,255,255,0.05); border-radius: 8px; padding: 2px 6px; }
       body.focus-mode .line.active{ background: rgba(95,168,255,0.12); }
 
+      /* Site chrome animations for focus mode */
+      .nav,
+      .footer{
+        transition: transform 0.35s ease, opacity 0.3s ease;
+        transform: translateY(0);
+        opacity: 1;
+      }
+      body.focus-mode .nav{
+        transform: translateY(-100%);
+        opacity: 0;
+        pointer-events: none;
+      }
+      body.focus-mode .footer{
+        transform: translateY(100%);
+        opacity: 0;
+        pointer-events: none;
+      }
+
       /* Bottom HUD visible only in focus mode */
       #focusHud{
         position: fixed; left: 50%; bottom: 18px; transform: translateX(-50%);


### PR DESCRIPTION
## Summary
- fade and slide the global header and footer out of view when focus mode is active so the workspace is distraction-free

## Testing
- Manually toggled focus mode in the writer

------
https://chatgpt.com/codex/tasks/task_e_68db07b81310832d99c436090dc917bf