### PR TITLE
Adjust script writer tab controls

### DIFF
--- a/use-cases/screenplay-writing.html
+++ b/use-cases/screenplay-writing.html
@@ -299,7 +299,6 @@
 
         <!-- non-essential buttons collapse in focus mode -->
         <div class="topbar-group non-essential" role="group" aria-label="Quick panel toggles">
-          <button class="btn" type="button" data-tab-btn="write">Write</button>
           <button class="btn" type="button" id="timelineModeBtn">Timeline</button>
         </div>
 
@@ -334,7 +333,7 @@
 
         <div class="panel">
           <div class="tab-header" id="rightTabBar">
-            <button class="tab-btn" data-tab-btn="write">Write</button>
+            <button class="tab-btn" data-tab-btn="write">Script</button>
             <button class="tab-btn" data-tab-btn="characters">Characters</button>
             <button class="tab-btn" data-tab-btn="set">Set</button>
             <button class="tab-btn" data-tab-btn="sound">Sound</button>


### PR DESCRIPTION
## Summary
- remove the redundant Write button from the top toolbar on the screenplay writing page
- relabel the remaining Write tab to Script for clarity

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db15b3fdd8832d83e05a1136b73bf0