### PR TITLE
Add Supabase documentation and schema for member auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# studioorganize-site
+# StudioOrganize Site
+
+This repository contains the static marketing site for StudioOrganize. It is built as a lightweight static site so it can be hosted on any static file host (GitHub Pages, Netlify, etc.).
+
+## Local development
+
+Because this is a static site, local development simply involves opening the HTML files in a browser or serving the root directory with a simple HTTP server such as `python -m http.server`.
+
+## Supabase authentication & member area
+
+User authentication and member data are powered by [Supabase](https://supabase.com/). To understand how the Supabase project is structured and how the site communicates with it, read [`SUPABASE.md`](SUPABASE.md).
+
+Environment variables required to interact with Supabase:
+
+```
+SUPABASE_URL=https://ycgqgkwwitqunabowswi.supabase.co
+SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InljZ3Fna3d3aXRxdW5hYm93c3dpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTkxNTg2NTAsImV4cCI6MjA3NDczNDY1MH0.W0mKqZlHVn6tRYSyZ4VRK4zCpCPC1ICwqtqoWrQMBuU
+```
+
+> ⚠️  Only the `anon` key should be embedded in the browser. Service-role keys must never be committed to the repository or exposed to browsers.
+
+SQL migrations and schema documentation for Supabase live in the [`supabase/`](supabase/) directory.
+

--- a/SUPABASE.md
+++ b/SUPABASE.md
@@ -1,0 +1,82 @@
+# Supabase Integration Guide
+
+This document explains how StudioOrganize uses Supabase for authentication and member data. The Supabase project for this site lives at `https://ycgqgkwwitqunabowswi.supabase.co`.
+
+## Overview
+
+The site relies on Supabase Auth to allow members to create accounts and sign in. The Supabase JavaScript client is loaded in the browser to perform the following actions:
+
+- `signUp({ email, password, options })` – create a new account and optional profile information.
+- `signInWithPassword({ email, password })` – allow returning members to log in.
+- `getSession()` / `onAuthStateChange()` – persist login state between page visits and show/hide member-only UI.
+- `from('profiles')` queries – fetch and update member profile data stored in the `profiles` table.
+
+Profiles are stored in the public schema and reference Supabase's `auth.users` table. Row Level Security (RLS) ensures that each signed-in member can only view and modify their own profile data.
+
+Supabase SQL schema files live in [`supabase/schema.sql`](supabase/schema.sql). Run the SQL file inside the Supabase SQL editor (or the CLI) to set up the necessary tables, triggers, and policies.
+
+## Environment variables
+
+Expose the following values to the frontend (e.g., via a `.env` file if you are using a local dev server or bundler):
+
+```
+SUPABASE_URL=https://ycgqgkwwitqunabowswi.supabase.co
+SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InljZ3Fna3d3aXRxdW5hYm93c3dpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTkxNTg2NTAsImV4cCI6MjA3NDczNDY1MH0.W0mKqZlHVn6tRYSyZ4VRK4zCpCPC1ICwqtqoWrQMBuU
+```
+
+When deploying, configure these values in your hosting platform's environment variable settings.
+
+## Initializing the client in the browser
+
+Add the Supabase client to your HTML templates. For example:
+
+```html
+<script type="module">
+  import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+  const supabase = createClient(
+    window.ENV.SUPABASE_URL,
+    window.ENV.SUPABASE_ANON_KEY
+  );
+
+  async function initializeAuth() {
+    const { data: { session } } = await supabase.auth.getSession();
+
+    if (session) {
+      document.body.classList.add('is-authenticated');
+    }
+
+    supabase.auth.onAuthStateChange((_event, currentSession) => {
+      document.body.classList.toggle('is-authenticated', !!currentSession);
+    });
+  }
+
+  initializeAuth();
+</script>
+```
+
+You can adapt this snippet to your build setup. The key steps are to:
+
+1. Create a single Supabase client with your URL and anon key.
+2. Handle `signUp`, `signInWithPassword`, and `signOut` events via form submissions or buttons.
+3. Listen to `onAuthStateChange` to update the UI when the user logs in or out.
+4. Use `supabase.from('profiles')` queries to read and persist profile information.
+
+## Member profile lifecycle
+
+1. When a new user signs up, a database trigger automatically inserts a row into `public.profiles` with the same UUID as the user.
+2. Row Level Security policies allow each user to read and update only their own profile.
+3. Use `supabase.functions.invoke` or direct `profiles` updates to store optional metadata such as studio name, phone number, etc.
+
+Refer to the schema file for exact column names and policies.
+
+## Testing the workflow
+
+1. Open the Supabase Dashboard and run the SQL in [`supabase/schema.sql`](supabase/schema.sql) using the SQL editor.
+2. In the Authentication settings, enable email/password sign-ups and configure any required email templates (e.g., confirmation emails).
+3. Load the site locally, open the browser console, and instantiate the Supabase client as shown above.
+4. Call `supabase.auth.signUp({ email, password })` to create a new account. Confirm the email if required by your project settings.
+5. Use `supabase.auth.signInWithPassword` to verify that login works and that you can fetch/update your profile using `supabase.from('profiles')` queries.
+
+This documentation should give you everything needed to wire the frontend forms to Supabase for user registration and login.
+

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,79 @@
+-- StudioOrganize Supabase schema
+-- Run this file inside the Supabase SQL editor or via `supabase db push`
+
+-- Ensure the pgcrypto extension is available for generating UUIDs if needed
+create extension if not exists "pgcrypto";
+
+-- Member profile table tied to Supabase Auth users
+create table if not exists public.profiles (
+    id uuid primary key references auth.users (id) on delete cascade,
+    email text unique,
+    full_name text,
+    studio_name text,
+    phone text,
+    created_at timestamptz default timezone('utc', now()) not null,
+    updated_at timestamptz default timezone('utc', now()) not null
+);
+
+-- Keep updated_at current automatically
+create or replace function public.set_current_timestamp()
+returns trigger as $$
+begin
+    new.updated_at := timezone('utc', now());
+    return new;
+end;
+$$ language plpgsql;
+
+create trigger profiles_set_timestamp
+before update on public.profiles
+for each row execute function public.set_current_timestamp();
+
+-- Automatically create a profile row when a user signs up
+create or replace function public.handle_new_user()
+returns trigger as $$
+begin
+    insert into public.profiles (id, email)
+    values (new.id, new.email)
+    on conflict (id) do nothing;
+    return new;
+end;
+$$ language plpgsql security definer;
+
+create trigger on_auth_user_created
+after insert on auth.users
+for each row execute function public.handle_new_user();
+
+-- Row Level Security policies
+alter table public.profiles enable row level security;
+
+drop policy if exists "Profiles are viewable by owners" on public.profiles;
+create policy "Profiles are viewable by owners"
+    on public.profiles
+    for select
+    using (auth.uid() = id);
+
+drop policy if exists "Profiles are editable by owners" on public.profiles;
+create policy "Profiles are editable by owners"
+    on public.profiles
+    for update
+    using (auth.uid() = id)
+    with check (auth.uid() = id);
+
+-- Allow insert via service role (used by trigger) and self-service sign-up
+-- No explicit insert policy is needed because inserts come from the trigger.
+
+-- Helper view for admin dashboards (requires service role)
+create or replace view public.member_directory as
+select
+    p.id,
+    p.email,
+    p.full_name,
+    p.studio_name,
+    p.phone,
+    p.created_at,
+    p.updated_at
+from public.profiles p;
+
+-- Grant read access on the view to authenticated users if needed (optional)
+-- revoke all on public.member_directory from anon;
+-- grant select on public.member_directory to authenticated;


### PR DESCRIPTION
## Summary
- add a Supabase integration guide that explains the auth flow and configuration
- document the Supabase project details and environment variables in the main README
- provide a schema SQL file that creates the profiles table, triggers, and RLS policies

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc1d9eb8b0832dbaab88a7b9cc0f64