### PR TITLE
Add account entry point and align navigation styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,15 +5,16 @@
 <header class="header"><div class="container nav">
   <a class="brand" href="/"><span class="dot"></span>StudioOrganize</a>
   <nav class="menu">
+    <a class="menu__link" href="/">Home</a>
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
       </div>
     </div>
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -22,9 +23,11 @@
         <a href="/use-cases/set-design.html">Set / Production Design</a>
       </div>
     </div>
-    <a href="/faq.html">FAQ</a><a class="active" href="/about.html">About</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
+    <a class="menu__link is-active" href="/about.html">About</a>
+    <a class="menu__link" href="mailto:hello@studioorganize.com">Contact</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="cta" href="mailto:hello@studioorganize.com">Contact</a>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </div></header>
 <main class="container">

--- a/account.html
+++ b/account.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign up / Log in — StudioOrganize</title>
+  <link rel="stylesheet" href="/assets/styles.css" />
+</head>
+<body>
+<header class="nav">
+  <a class="brand" href="/">StudioOrganize</a>
+  <nav class="menu">
+    <a class="menu__link" href="/">Home</a>
+    <div class="dropdown">
+      <button class="dropbtn" type="button">Products</button>
+      <div class="dropdown-content">
+        <a href="/products/#online">Subscribe &amp; save it online</a>
+        <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
+      </div>
+    </div>
+    <div class="dropdown">
+      <button class="dropbtn" type="button">Use Cases</button>
+      <div class="dropdown-content">
+        <a href="/use-cases/">All Use Cases</a>
+        <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
+        <a href="/use-cases/screenplay.html">Screenplay Script</a>
+        <a href="/use-cases/character-design.html">Character Design</a>
+        <a href="/use-cases/set-design.html">Set / Production Design</a>
+      </div>
+    </div>
+    <a class="menu__link" href="/about.html">About</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
+    <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
+    <a class="menu__cta" href="/account.html" aria-current="page">Sign up / Log in</a>
+  </nav>
+</header>
+
+<main class="section">
+  <h1>Sign up / Log in</h1>
+  <p class="lead">Access the StudioOrganize workspace or request a new account.</p>
+
+  <div class="grid cards" style="margin-top:24px">
+    <div class="card">
+      <h2>New here?</h2>
+      <p>StudioOrganize Online is rolling out gradually. Join the waitlist and we’ll send you a sign-up link as soon as your spot opens.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="mailto:support@studioorganize.com?subject=StudioOrganize%20Sign%20Up">Join the waitlist</a>
+        <a class="btn btn-ghost" href="/product/studioorganize.html">See what’s included</a>
+      </div>
+      <p class="muted" style="margin-top:12px">Already purchased the Google Sheets version? You can duplicate the templates from your receipt email.</p>
+    </div>
+
+    <div class="card">
+      <h2>Already a member?</h2>
+      <p>Use the login link below to open the hosted workspace. Bookmark it for quick access, and reach out if you need help.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="https://app.studioorganize.com" target="_blank" rel="noopener">Go to login</a>
+        <a class="btn btn-ghost" href="mailto:support@studioorganize.com?subject=StudioOrganize%20Login%20Help">Need help?</a>
+      </div>
+      <p class="muted" style="margin-top:12px">Lost access or changed your email? Contact support and we’ll get you back in.</p>
+    </div>
+  </div>
+</main>
+
+<footer class="footer">
+  <div class="footer__grid">
+    <div><strong>StudioOrganize</strong></div>
+    <div><a href="/products/">Products</a></div>
+    <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
+  </div>
+</footer>
+
+<script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+<script src="/assets/main.js" defer></script>
+</body>
+</html>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -55,17 +55,19 @@ img{max-width:100%;display:block}
 /* nav */
 .nav{display:flex;justify-content:space-between;align-items:center;padding:14px 18px;border-bottom:1px solid var(--line);position:sticky;top:0;background:var(--nav-bg);backdrop-filter:blur(10px);z-index:10}
 .brand{font-weight:800;letter-spacing:.2px}
-.nav a{margin-left:16px;color:var(--muted)}
-.nav a:hover{color:var(--text)}
-.menu{display:flex;gap:16px;align-items:center}
-.theme-toggle{border:1px solid var(--line);background:var(--chip);color:var(--muted);padding:8px 12px;border-radius:10px;cursor:pointer;font:inherit;transition:border-color .12s ease, color .12s ease, background .12s ease}
-.theme-toggle:hover{border-color:var(--acc);color:var(--text)}
+.menu{display:flex;gap:10px;align-items:center;flex-wrap:wrap;justify-content:flex-end}
+.menu__link,.dropbtn,.theme-toggle{display:inline-flex;align-items:center;gap:6px;padding:8px 12px;border-radius:10px;border:1px solid var(--line);background:var(--panel);color:var(--muted);font:inherit;font-weight:500;cursor:pointer;transition:color .12s ease,border-color .12s ease,background .12s ease,transform .12s ease;text-decoration:none}
+.menu__link:hover,.dropbtn:hover,.theme-toggle:hover{color:var(--text);border-color:var(--acc);background:var(--chip)}
+.menu__link.is-active{color:var(--text);border-color:var(--acc);background:var(--chip)}
+.menu__cta{display:inline-flex;align-items:center;gap:6px;padding:10px 18px;border-radius:12px;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#0b0f14;font-weight:700;box-shadow:0 10px 30px rgba(0,0,0,.25);transition:transform .12s ease}
+.menu__cta:hover{color:#0b0f14;transform:translateY(-1px)}
+.theme-toggle{background:var(--panel)}
 .theme-toggle:focus-visible{outline:2px solid var(--acc);outline-offset:2px}
 
 /* dropdown */
 .dropdown{position:relative}
-.dropbtn{border:1px solid var(--line);background:transparent;color:var(--muted);padding:8px 10px;border-radius:10px;cursor:pointer}
-.dropbtn:hover{color:var(--text);border-color:#2a2f39}
+.dropbtn{background:var(--panel)}
+.dropbtn:hover{color:var(--text)}
 .dropdown-content{display:none;position:absolute;right:0;min-width:230px;background:var(--panel);border:1px solid var(--line);border-radius:12px;box-shadow:0 10px 30px rgba(0,0,0,.35);padding:6px}
 .dropdown-content a{display:block;padding:10px 12px;border-radius:8px;color:var(--text)}
 .dropdown-content a:hover{background:var(--chip)}

--- a/faq.html
+++ b/faq.html
@@ -5,15 +5,16 @@
 <header class="header"><div class="container nav">
   <a class="brand" href="/"><span class="dot"></span>StudioOrganize</a>
   <nav class="menu">
+    <a class="menu__link" href="/">Home</a>
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
       </div>
     </div>
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -22,9 +23,11 @@
         <a href="/use-cases/set-design.html">Set / Production Design</a>
       </div>
     </div>
-    <a class="active" href="/faq.html">FAQ</a><a href="/about.html">About</a>
+    <a class="menu__link is-active" href="/faq.html">FAQ</a>
+    <a class="menu__link" href="/about.html">About</a>
+    <a class="menu__link" href="mailto:hello@studioorganize.com">Contact</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="cta" href="mailto:hello@studioorganize.com">Contact</a>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </div></header>
 <main class="container">

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
@@ -21,7 +21,7 @@
     </div>
 
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -31,9 +31,10 @@
       </div>
     </div>
 
-    <a href="/about.html">About</a>
-    <a href="/faq.html">FAQ</a>
+    <a class="menu__link" href="/about.html">About</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </header>
 

--- a/product/1week-story
+++ b/product/1week-story
@@ -10,8 +10,9 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
+    <a class="menu__link" href="/">Home</a>
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
@@ -19,7 +20,7 @@
     </div>
 
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -29,8 +30,9 @@
       </div>
     </div>
 
-    <a href="/faq.html">FAQ</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </header>
 

--- a/product/personal.html
+++ b/product/personal.html
@@ -10,15 +10,16 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
+    <a class="menu__link" href="/">Home</a>
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
       </div>
     </div>
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -27,8 +28,9 @@
         <a href="/use-cases/set-design.html">Set / Production Design</a>
       </div>
     </div>
-    <a href="/faq.html">FAQ</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </header>
 

--- a/product/studioorganize.html
+++ b/product/studioorganize.html
@@ -10,8 +10,9 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
+    <a class="menu__link" href="/">Home</a>
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
@@ -19,7 +20,7 @@
     </div>
 
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -29,8 +30,9 @@
       </div>
     </div>
 
-    <a href="/faq.html">FAQ</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </header>
 

--- a/product/template.html
+++ b/product/template.html
@@ -7,15 +7,16 @@
 <header class="header"><div class="container nav">
   <a class="brand" href="/"><span class="dot"></span>StudioOrganize</a>
   <nav class="menu">
+    <a class="menu__link" href="/">Home</a>
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
       </div>
     </div>
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -24,9 +25,11 @@
         <a href="/use-cases/set-design.html">Set / Production Design</a>
       </div>
     </div>
-    <a href="/faq.html">FAQ</a><a href="/about.html">About</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
+    <a class="menu__link" href="/about.html">About</a>
+    <a class="menu__link" href="mailto:hello@studioorganize.com">Contact</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="cta" href="mailto:hello@studioorganize.com">Contact</a>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </div></header>
 

--- a/products/index.html
+++ b/products/index.html
@@ -10,10 +10,10 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
-    <a href="/">Home</a>
+    <a class="menu__link" href="/">Home</a>
 
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
@@ -21,7 +21,7 @@
     </div>
 
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -31,9 +31,10 @@
       </div>
     </div>
 
-    <a href="/about.html">About</a>
-    <a href="/faq.html">FAQ</a>
+    <a class="menu__link" href="/about.html">About</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </header>
 

--- a/products/personal.html
+++ b/products/personal.html
@@ -5,15 +5,16 @@
 <header class="header"><div class="container nav">
   <a class="brand" href="/"><span class="dot"></span>StudioOrganize</a>
   <nav class="menu">
+    <a class="menu__link" href="/">Home</a>
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
       </div>
     </div>
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -22,9 +23,11 @@
         <a href="/use-cases/set-design.html">Set / Production Design</a>
       </div>
     </div>
-    <a href="/faq.html">FAQ</a><a href="/about.html">About</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
+    <a class="menu__link" href="/about.html">About</a>
+    <a class="menu__link" href="mailto:hello@studioorganize.com">Contact</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="cta" href="mailto:hello@studioorganize.com">Contact</a>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </div></header>
 

--- a/use-cases/character-design.html
+++ b/use-cases/character-design.html
@@ -10,15 +10,16 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
+    <a class="menu__link" href="/">Home</a>
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
       </div>
     </div>
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -27,9 +28,10 @@
         <a href="/use-cases/set-design.html">Set / Production Design</a>
       </div>
     </div>
-    <a href="/about.html">About</a>
-    <a href="/faq.html">FAQ</a>
+    <a class="menu__link" href="/about.html">About</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </header>
 

--- a/use-cases/generate-ideas.html
+++ b/use-cases/generate-ideas.html
@@ -11,15 +11,16 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
+    <a class="menu__link" href="/">Home</a>
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
       </div>
     </div>
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -28,9 +29,10 @@
         <a href="/use-cases/set-design.html">Set / Production Design</a>
       </div>
     </div>
-    <a href="/about.html">About</a>
-    <a href="/faq.html">FAQ</a>
+    <a class="menu__link" href="/about.html">About</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </header>
 

--- a/use-cases/index.html
+++ b/use-cases/index.html
@@ -11,15 +11,16 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
+    <a class="menu__link" href="/">Home</a>
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
       </div>
     </div>
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -28,9 +29,10 @@
         <a href="/use-cases/set-design.html">Set / Production Design</a>
       </div>
     </div>
-    <a href="/about.html">About</a>
-    <a href="/faq.html">FAQ</a>
+    <a class="menu__link" href="/about.html">About</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </header>
 

--- a/use-cases/screenplay-writing.html
+++ b/use-cases/screenplay-writing.html
@@ -10,15 +10,16 @@
   <header class="nav">
     <a class="brand" href="/">StudioOrganize</a>
     <nav class="menu">
+      <a class="menu__link" href="/">Home</a>
       <div class="dropdown">
-        <button class="dropbtn">Products</button>
+        <button class="dropbtn" type="button">Products</button>
         <div class="dropdown-content">
           <a href="/products/#online">Subscribe &amp; save it online</a>
           <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
         </div>
       </div>
       <div class="dropdown">
-        <button class="dropbtn">Use Cases</button>
+        <button class="dropbtn" type="button">Use Cases</button>
         <div class="dropdown-content">
           <a href="/use-cases/">All Use Cases</a>
           <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -27,9 +28,10 @@
           <a href="/use-cases/set-design.html">Set / Production Design</a>
         </div>
       </div>
-      <a href="/about.html">About</a>
-      <a href="/faq.html">FAQ</a>
+      <a class="menu__link" href="/about.html">About</a>
+      <a class="menu__link" href="/faq.html">FAQ</a>
       <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
+      <a class="menu__cta" href="/account.html">Sign up / Log in</a>
     </nav>
   </header>
 

--- a/use-cases/screenplay.html
+++ b/use-cases/screenplay.html
@@ -10,15 +10,16 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
+    <a class="menu__link" href="/">Home</a>
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
       </div>
     </div>
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -27,9 +28,10 @@
         <a href="/use-cases/set-design.html">Set / Production Design</a>
       </div>
     </div>
-    <a href="/about.html">About</a>
-    <a href="/faq.html">FAQ</a>
+    <a class="menu__link" href="/about.html">About</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </header>
 

--- a/use-cases/set-design.html
+++ b/use-cases/set-design.html
@@ -10,15 +10,16 @@
 <header class="nav">
   <a class="brand" href="/">StudioOrganize</a>
   <nav class="menu">
+    <a class="menu__link" href="/">Home</a>
     <div class="dropdown">
-      <button class="dropbtn">Products</button>
+      <button class="dropbtn" type="button">Products</button>
       <div class="dropdown-content">
         <a href="/products/#online">Subscribe &amp; save it online</a>
         <a href="/products/#sheets">Google Sheets — keep the database yourself</a>
       </div>
     </div>
     <div class="dropdown">
-      <button class="dropbtn">Use Cases</button>
+      <button class="dropbtn" type="button">Use Cases</button>
       <div class="dropdown-content">
         <a href="/use-cases/">All Use Cases</a>
         <a href="/use-cases/generate-ideas.html">Generate Ideas</a>
@@ -27,9 +28,10 @@
         <a href="/use-cases/set-design.html">Set / Production Design</a>
       </div>
     </div>
-    <a href="/about.html">About</a>
-    <a href="/faq.html">FAQ</a>
+    <a class="menu__link" href="/about.html">About</a>
+    <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
+    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
   </nav>
 </header>
 


### PR DESCRIPTION
## Summary
- restyle the site navigation to use consistent pill links and a gradient call-to-action across every marketing page
- add a dedicated Sign up / Log in CTA and supporting account landing page with waitlist and login links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc25704f24832db6e2b6144726e95e