### PR TITLE
Add Supabase-powered auth modal and guidance

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,7 @@
     <a class="menu__link is-active" href="/about.html">About</a>
     <a class="menu__link" href="mailto:hello@studioorganize.com">Contact</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </div></header>
 <main class="container">
@@ -37,5 +37,6 @@
 </main>
 <footer class="footer"><div class="container">© <span id="y"></span> StudioOrganize</div></footer>
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+<script type="module" src="assets/auth.js"></script>
 <script src="assets/main.js" defer></script>
 </body></html>

--- a/account.html
+++ b/account.html
@@ -31,34 +31,23 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html" aria-current="page">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </header>
 
 <main class="section">
-  <h1>Sign up / Log in</h1>
-  <p class="lead">Access the StudioOrganize workspace or request a new account.</p>
+  <h1>Access your StudioOrganize account</h1>
+  <p class="lead">Use the sign-in window to create an account or log in. It opens automatically on this page.</p>
 
-  <div class="grid cards" style="margin-top:24px">
-    <div class="card">
-      <h2>New here?</h2>
-      <p>StudioOrganize Online is rolling out gradually. Join the waitlist and we’ll send you a sign-up link as soon as your spot opens.</p>
-      <div class="cta-row">
-        <a class="btn btn-primary" href="mailto:support@studioorganize.com?subject=StudioOrganize%20Sign%20Up">Join the waitlist</a>
-        <a class="btn btn-ghost" href="/product/studioorganize.html">See what’s included</a>
-      </div>
-      <p class="muted" style="margin-top:12px">Already purchased the Google Sheets version? You can duplicate the templates from your receipt email.</p>
+  <div class="card card--lg" style="margin-top:24px;max-width:640px">
+    <h2>Need the account window again?</h2>
+    <p>Use the buttons below to reopen the popup any time. Sign-ups happen instantly through our secure Supabase database.</p>
+    <div class="cta-row" style="margin-top:12px">
+      <button class="btn btn-primary" type="button" data-open-auth="signup" data-auth-no-redirect="true">Sign up and create account</button>
+      <button class="btn btn-ghost" type="button" data-open-auth="login" data-auth-no-redirect="true">Log in</button>
+      <a class="btn btn-ghost" href="mailto:support@studioorganize.com?subject=StudioOrganize%20Account%20Help">Need help?</a>
     </div>
-
-    <div class="card">
-      <h2>Already a member?</h2>
-      <p>Use the login link below to open the hosted workspace. Bookmark it for quick access, and reach out if you need help.</p>
-      <div class="cta-row">
-        <a class="btn btn-primary" href="https://app.studioorganize.com" target="_blank" rel="noopener">Go to login</a>
-        <a class="btn btn-ghost" href="mailto:support@studioorganize.com?subject=StudioOrganize%20Login%20Help">Need help?</a>
-      </div>
-      <p class="muted" style="margin-top:12px">Lost access or changed your email? Contact support and we’ll get you back in.</p>
-    </div>
+    <p class="muted" style="margin-top:12px">Tip: once you’re signed in, bookmark <a href="https://app.studioorganize.com" target="_blank" rel="noopener">app.studioorganize.com</a> for quick access.</p>
   </div>
 </main>
 
@@ -71,6 +60,21 @@
 </footer>
 
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+<script type="module" src="/assets/auth.js"></script>
 <script src="/assets/main.js" defer></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const open = (mode = 'signup') => {
+      if (typeof window.openAuthModal === 'function'){
+        window.openAuthModal(mode);
+      }
+    };
+    if (typeof window.openAuthModal === 'function'){
+      open('signup');
+    } else {
+      window.addEventListener('auth:ready', () => open('signup'), { once: true });
+    }
+  });
+</script>
 </body>
 </html>

--- a/assets/auth.js
+++ b/assets/auth.js
@@ -1,0 +1,305 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const SUPABASE_URL = 'https://ycgqgkwwitqunabowswi.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InljZ3Fna3d3aXRxdW5hYm93c3dpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTkxNTg2NTAsImV4cCI6MjA3NDczNDY1MH0.W0mKqZlHVn6tRYSyZ4VRK4zCpCPC1ICwqtqoWrQMBuU';
+const WORKSPACE_URL = 'https://app.studioorganize.com';
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+function qs(selector, scope = document){
+  return scope.querySelector(selector);
+}
+
+function qsa(selector, scope = document){
+  return Array.from(scope.querySelectorAll(selector));
+}
+
+function createModal(){
+  const wrapper = document.createElement('div');
+  wrapper.className = 'auth-modal';
+  wrapper.dataset.mode = 'signup';
+  wrapper.setAttribute('aria-hidden', 'true');
+  wrapper.innerHTML = `
+    <div class="auth-modal__overlay" data-auth-close tabindex="-1"></div>
+    <div class="auth-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="auth-modal-title">
+      <button class="auth-modal__close" type="button" data-auth-close aria-label="Close sign in dialog">×</button>
+      <header class="auth-modal__header">
+        <h2 id="auth-modal-title">Sign up and create account</h2>
+        <p class="auth-modal__subtitle">Access StudioOrganize Online instantly after confirming your email.</p>
+      </header>
+      <form class="auth-form" data-auth-form="signup" novalidate>
+        <div class="auth-form__field">
+          <label for="auth-signup-name">Name</label>
+          <input id="auth-signup-name" name="name" type="text" autocomplete="name" placeholder="Your name" />
+        </div>
+        <div class="auth-form__field">
+          <label for="auth-signup-email">Email</label>
+          <input id="auth-signup-email" name="email" type="email" autocomplete="email" placeholder="you@example.com" required />
+        </div>
+        <div class="auth-form__field">
+          <label for="auth-signup-password">Password</label>
+          <input id="auth-signup-password" name="password" type="password" autocomplete="new-password" minlength="8" placeholder="At least 8 characters" required />
+        </div>
+        <p class="auth-form__status" data-auth-status="signup" role="status" aria-live="polite"></p>
+        <button class="btn btn-primary auth-form__submit" type="submit">Sign up and create account</button>
+        <p class="auth-form__switch">Already a creator? <button type="button" data-switch-mode="login">Log in</button></p>
+      </form>
+      <form class="auth-form" data-auth-form="login" hidden novalidate>
+        <div class="auth-form__field">
+          <label for="auth-login-email">Email</label>
+          <input id="auth-login-email" name="email" type="email" autocomplete="email" placeholder="you@example.com" required />
+        </div>
+        <div class="auth-form__field">
+          <label for="auth-login-password">Password</label>
+          <input id="auth-login-password" name="password" type="password" autocomplete="current-password" required />
+        </div>
+        <p class="auth-form__status" data-auth-status="login" role="status" aria-live="polite"></p>
+        <button class="btn btn-primary auth-form__submit" type="submit">Log in</button>
+        <p class="auth-form__switch">New to StudioOrganize? <button type="button" data-switch-mode="signup">Create an account</button></p>
+      </form>
+    </div>
+  `;
+  return wrapper;
+}
+
+const modal = createModal();
+document.body.appendChild(modal);
+
+const signupForm = qs('[data-auth-form="signup"]', modal);
+const loginForm = qs('[data-auth-form="login"]', modal);
+const titleEl = qs('#auth-modal-title', modal);
+const subtitleEl = qs('.auth-modal__subtitle', modal);
+const statusSignup = qs('[data-auth-status="signup"]', modal);
+const statusLogin = qs('[data-auth-status="login"]', modal);
+let currentMode = 'signup';
+let previouslyFocused = null;
+let latestSession = null;
+
+function setStatus(el, message, type = 'info'){
+  if (!el) return;
+  el.textContent = message || '';
+  el.dataset.statusType = type;
+}
+
+function disableForm(form, disabled){
+  qsa('input, button', form).forEach(el => {
+    el.disabled = disabled;
+  });
+}
+
+function focusFirstField(){
+  const form = currentMode === 'signup' ? signupForm : loginForm;
+  const field = form ? form.querySelector('input:not([type="hidden"])') : null;
+  if (field) field.focus();
+}
+
+function setMode(mode){
+  currentMode = mode === 'login' ? 'login' : 'signup';
+  modal.dataset.mode = currentMode;
+  if (currentMode === 'signup'){
+    signupForm.hidden = false;
+    loginForm.hidden = true;
+    titleEl.textContent = 'Sign up and create account';
+    subtitleEl.textContent = 'Access StudioOrganize Online instantly after confirming your email.';
+  } else {
+    signupForm.hidden = true;
+    loginForm.hidden = false;
+    titleEl.textContent = 'Welcome back';
+    subtitleEl.textContent = 'Log in to continue building your projects.';
+  }
+  requestAnimationFrame(focusFirstField);
+}
+
+function trapFocus(e){
+  if (!modal.classList.contains('is-open')) return;
+  if (e.key !== 'Tab') return;
+  const focusable = qsa('button:not([disabled]), [href], input:not([disabled]), textarea, select, [tabindex]:not([tabindex="-1"])', modal)
+    .filter(el => el.offsetParent !== null);
+  if (!focusable.length) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (e.shiftKey && document.activeElement === first){
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last){
+    e.preventDefault();
+    first.focus();
+  }
+}
+
+function openAuthModal(mode = 'signup'){
+  previouslyFocused = document.activeElement;
+  setMode(mode);
+  modal.classList.add('is-open');
+  modal.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('auth-modal-open');
+  focusFirstField();
+}
+
+function closeAuthModal(){
+  modal.classList.remove('is-open');
+  modal.setAttribute('aria-hidden', 'true');
+  document.body.classList.remove('auth-modal-open');
+  if (previouslyFocused && typeof previouslyFocused.focus === 'function'){
+    previouslyFocused.focus();
+  }
+}
+
+function handleEscape(e){
+  if (e.key === 'Escape' && modal.classList.contains('is-open')){
+    closeAuthModal();
+  }
+}
+
+document.addEventListener('keydown', trapFocus);
+document.addEventListener('keydown', handleEscape);
+
+modal.addEventListener('click', e => {
+  if (e.target && e.target.matches('[data-auth-close]')){
+    closeAuthModal();
+  }
+});
+
+modal.addEventListener('click', e => {
+  const switcher = e.target.closest('[data-switch-mode]');
+  if (!switcher) return;
+  e.preventDefault();
+  setStatus(statusLogin, '');
+  setStatus(statusSignup, '');
+  setMode(switcher.dataset.switchMode || 'signup');
+});
+
+async function handleSignup(e){
+  e.preventDefault();
+  if (!signupForm.reportValidity()){
+    return;
+  }
+  setStatus(statusSignup, 'Creating your account…', 'info');
+  disableForm(signupForm, true);
+  const formData = new FormData(signupForm);
+  const name = (formData.get('name') || '').toString().trim();
+  const email = (formData.get('email') || '').toString().trim();
+  const password = (formData.get('password') || '').toString();
+  try {
+    const options = name ? { data: { full_name: name } } : undefined;
+    const { error } = await supabase.auth.signUp({ email, password, options });
+    if (error){
+      throw error;
+    }
+    setStatus(statusSignup, 'Check your inbox to confirm your email. Once confirmed you can sign in and access the workspace.', 'success');
+    signupForm.reset();
+  } catch (error) {
+    const message = error && typeof error.message === 'string' ? error.message : 'Something went wrong. Please try again.';
+    setStatus(statusSignup, message, 'error');
+  } finally {
+    disableForm(signupForm, false);
+  }
+}
+
+async function handleLogin(e){
+  e.preventDefault();
+  if (!loginForm.reportValidity()){
+    return;
+  }
+  setStatus(statusLogin, 'Signing you in…', 'info');
+  disableForm(loginForm, true);
+  const formData = new FormData(loginForm);
+  const email = (formData.get('email') || '').toString().trim();
+  const password = (formData.get('password') || '').toString();
+  try {
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error){
+      throw error;
+    }
+    setStatus(statusLogin, 'Success! Redirecting to your workspace…', 'success');
+    setTimeout(() => {
+      window.location.href = WORKSPACE_URL;
+    }, 900);
+  } catch (error) {
+    const message = error && typeof error.message === 'string' ? error.message : 'Unable to log in. Please check your details and try again.';
+    setStatus(statusLogin, message, 'error');
+  } finally {
+    disableForm(loginForm, false);
+  }
+}
+
+signupForm.addEventListener('submit', handleSignup);
+loginForm.addEventListener('submit', handleLogin);
+
+function bindOpeners(){
+  qsa('[data-open-auth]').forEach(btn => {
+    if (btn.dataset.authBound) return;
+    btn.dataset.authBound = 'true';
+    if (!btn.dataset.authOriginalLabel){
+      btn.dataset.authOriginalLabel = btn.textContent.trim();
+    }
+    if (!btn.dataset.authDefaultAction){
+      const initialAction = btn.dataset.openAuth || btn.dataset.openAuthMode || btn.dataset.openAuthType || btn.dataset.openAuthState || 'signup';
+      btn.dataset.authDefaultAction = initialAction;
+      btn.dataset.openAuth = initialAction;
+    }
+    const handler = () => {
+      const action = btn.dataset.openAuth || btn.dataset.openAuthMode || btn.dataset.openAuthType || btn.dataset.openAuthState || 'signup';
+      if (action === 'workspace'){
+        window.location.href = WORKSPACE_URL;
+        return;
+      }
+      openAuthModal(action);
+    };
+    btn.addEventListener('click', handler);
+    btn._authHandler = handler;
+    if (btn.tagName === 'BUTTON' && !btn.hasAttribute('type')){
+      btn.setAttribute('type', 'button');
+    }
+  });
+  if (latestSession !== null){
+    updateCtas(latestSession);
+  }
+}
+
+function updateCtas(session){
+  latestSession = session;
+  const authed = Boolean(session);
+  qsa('[data-open-auth]').forEach(btn => {
+    if (!(btn instanceof HTMLElement)) return;
+    const original = btn.dataset.authOriginalLabel || btn.textContent;
+    const defaultAction = btn.dataset.authDefaultAction || 'signup';
+    const skipRedirect = btn.dataset.authNoRedirect === 'true';
+    if (authed && !skipRedirect){
+      btn.textContent = 'Open workspace';
+      btn.dataset.openAuth = 'workspace';
+    } else {
+      btn.textContent = original;
+      btn.dataset.openAuth = defaultAction;
+    }
+  });
+}
+
+function init(){
+  bindOpeners();
+  const observer = new MutationObserver(bindOpeners);
+  observer.observe(document.body, { childList: true, subtree: true });
+}
+
+if (document.readyState === 'loading'){
+  document.addEventListener('DOMContentLoaded', init, { once: true });
+} else {
+  init();
+}
+
+supabase.auth.getSession().then(({ data }) => {
+  const session = data?.session || null;
+  updateCtas(session);
+  document.body.classList.toggle('is-authenticated', !!session);
+});
+
+supabase.auth.onAuthStateChange((_event, session) => {
+  updateCtas(session);
+  document.body.classList.toggle('is-authenticated', !!session);
+});
+
+window.openAuthModal = openAuthModal;
+window.closeAuthModal = closeAuthModal;
+window.supabaseClient = supabase;
+
+window.dispatchEvent(new CustomEvent('auth:ready', { detail: { supabase } }));

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -59,10 +59,36 @@ img{max-width:100%;display:block}
 .menu__link,.dropbtn,.theme-toggle{display:inline-flex;align-items:center;gap:6px;padding:8px 12px;border-radius:10px;border:1px solid var(--line);background:var(--panel);color:var(--muted);font:inherit;font-weight:500;cursor:pointer;transition:color .12s ease,border-color .12s ease,background .12s ease,transform .12s ease;text-decoration:none}
 .menu__link:hover,.dropbtn:hover,.theme-toggle:hover{color:var(--text);border-color:var(--acc);background:var(--chip)}
 .menu__link.is-active{color:var(--text);border-color:var(--acc);background:var(--chip)}
-.menu__cta{display:inline-flex;align-items:center;gap:6px;padding:10px 18px;border-radius:12px;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#0b0f14;font-weight:700;box-shadow:0 10px 30px rgba(0,0,0,.25);transition:transform .12s ease}
+.menu__cta{display:inline-flex;align-items:center;gap:6px;padding:10px 18px;border-radius:12px;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#0b0f14;font-weight:700;box-shadow:0 10px 30px rgba(0,0,0,.25);transition:transform .12s ease;border:none;cursor:pointer;font:inherit}
 .menu__cta:hover{color:#0b0f14;transform:translateY(-1px)}
+.menu__cta:focus-visible{outline:2px solid var(--acc);outline-offset:3px}
 .theme-toggle{background:var(--panel)}
 .theme-toggle:focus-visible{outline:2px solid var(--acc);outline-offset:2px}
+
+/* auth modal */
+.auth-modal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:24px;visibility:hidden;opacity:0;transition:opacity .18s ease,visibility .18s ease;z-index:100}
+.auth-modal.is-open{visibility:visible;opacity:1}
+.auth-modal__overlay{position:absolute;inset:0;background:rgba(10,15,22,0.72);backdrop-filter:blur(4px)}
+.auth-modal__dialog{position:relative;z-index:1;width:min(460px,100%);background:var(--panel);border-radius:18px;padding:28px;border:1px solid var(--line);box-shadow:0 30px 60px rgba(0,0,0,.45);display:flex;flex-direction:column;gap:18px}
+.auth-modal__close{position:absolute;top:12px;right:12px;border:none;background:transparent;color:var(--muted);font-size:24px;line-height:1;cursor:pointer;padding:4px;border-radius:50%}
+.auth-modal__close:hover{color:var(--text);background:var(--chip)}
+.auth-modal__header h2{margin:0;font-size:24px}
+.auth-modal__subtitle{margin:6px 0 0;color:var(--muted)}
+.auth-form{display:flex;flex-direction:column;gap:14px}
+.auth-form[hidden]{display:none !important}
+.auth-form__field{display:flex;flex-direction:column;gap:6px}
+.auth-form__field label{font-weight:600;font-size:14px}
+.auth-form__field input{padding:12px;border-radius:12px;border:1px solid var(--line);background:var(--field);color:var(--text);font:inherit}
+.auth-form__field input:focus-visible{outline:2px solid var(--acc);outline-offset:1px;border-color:var(--acc)}
+.auth-form__status{min-height:20px;font-size:14px;margin:0;color:var(--muted)}
+.auth-form__status[data-status-type="success"]{color:#34d399}
+.auth-form__status[data-status-type="error"]{color:#f87171}
+.auth-form__submit{width:100%;justify-content:center}
+.auth-form__switch{font-size:14px;color:var(--muted);margin:0}
+.auth-form__switch button{background:none;border:none;color:var(--brand);font:inherit;font-weight:600;cursor:pointer;padding:0}
+.auth-form__switch button:hover{text-decoration:underline}
+
+body.auth-modal-open{overflow:hidden}
 
 /* dropdown */
 .dropdown{position:relative}

--- a/faq.html
+++ b/faq.html
@@ -27,7 +27,7 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="mailto:hello@studioorganize.com">Contact</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </div></header>
 <main class="container">
@@ -41,5 +41,6 @@
 </main>
 <footer class="footer"><div class="container">© <span id="y"></span> StudioOrganize</div></footer>
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+<script type="module" src="assets/auth.js"></script>
 <script src="assets/main.js" defer></script>
 </body></html>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </header>
 
@@ -187,6 +187,7 @@
   </div>
 </footer>
 
-<script src="/assets/main.js"></script>
+<script type="module" src="/assets/auth.js"></script>
+<script src="/assets/main.js" defer></script>
 </body>
 </html>

--- a/product/1week-story
+++ b/product/1week-story
@@ -32,7 +32,7 @@
 
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </header>
 
@@ -93,6 +93,7 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
   </div>
 </footer>
-<script src="/assets/main.js"></script>
+<script type="module" src="/assets/auth.js"></script>
+<script src="/assets/main.js" defer></script>
 </body>
 </html>

--- a/product/personal.html
+++ b/product/personal.html
@@ -30,7 +30,7 @@
     </div>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </header>
 
@@ -72,6 +72,7 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a></div>
   </div>
 </footer>
-<script src="/assets/main.js"></script>
+<script type="module" src="/assets/auth.js"></script>
+<script src="/assets/main.js" defer></script>
 </body>
 </html>

--- a/product/studioorganize.html
+++ b/product/studioorganize.html
@@ -32,7 +32,7 @@
 
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </header>
 
@@ -112,6 +112,7 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
   </div>
 </footer>
-<script src="/assets/main.js"></script>
+<script type="module" src="/assets/auth.js"></script>
+<script src="/assets/main.js" defer></script>
 </body>
 </html>

--- a/product/template.html
+++ b/product/template.html
@@ -29,7 +29,7 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="mailto:hello@studioorganize.com">Contact</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </div></header>
 
@@ -72,5 +72,6 @@
 
 <footer class="footer"><div class="container">© <span id="y"></span> StudioOrganize</div></footer>
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+<script type="module" src="../assets/auth.js"></script>
 <script src="../assets/main.js" defer></script>
 </body></html>

--- a/products/index.html
+++ b/products/index.html
@@ -34,7 +34,7 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </header>
 
@@ -89,6 +89,7 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a></div>
   </div>
 </footer>
-<script src="/assets/main.js"></script>
+<script type="module" src="/assets/auth.js"></script>
+<script src="/assets/main.js" defer></script>
 </body>
 </html>

--- a/products/personal.html
+++ b/products/personal.html
@@ -27,7 +27,7 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="mailto:hello@studioorganize.com">Contact</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </div></header>
 
@@ -48,5 +48,6 @@
 
 <footer class="footer"><div class="container">© <span id="y"></span> StudioOrganize</div></footer>
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+<script type="module" src="../assets/auth.js"></script>
 <script src="../assets/main.js" defer></script>
 </body></html>

--- a/use-cases/character-design.html
+++ b/use-cases/character-design.html
@@ -31,7 +31,7 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </header>
 
@@ -78,6 +78,7 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
   </div>
 </footer>
-<script src="/assets/main.js"></script>
+<script type="module" src="/assets/auth.js"></script>
+<script src="/assets/main.js" defer></script>
 </body>
 </html>

--- a/use-cases/generate-ideas.html
+++ b/use-cases/generate-ideas.html
@@ -32,7 +32,7 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </header>
 
@@ -98,6 +98,7 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
   </div>
 </footer>
-<script src="/assets/main.js"></script>
+<script type="module" src="/assets/auth.js"></script>
+<script src="/assets/main.js" defer></script>
 </body>
 </html>

--- a/use-cases/index.html
+++ b/use-cases/index.html
@@ -32,7 +32,7 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </header>
 
@@ -75,6 +75,7 @@
   </div>
 </footer>
 
-<script src="/assets/main.js"></script>
+<script type="module" src="/assets/auth.js"></script>
+<script src="/assets/main.js" defer></script>
 </body>
 </html>

--- a/use-cases/screenplay-writing.html
+++ b/use-cases/screenplay-writing.html
@@ -31,7 +31,7 @@
       <a class="menu__link" href="/about.html">About</a>
       <a class="menu__link" href="/faq.html">FAQ</a>
       <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-      <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+      <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
     </nav>
   </header>
 
@@ -2120,6 +2120,7 @@
       <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
     </div>
   </footer>
-  <script src="/assets/main.js"></script>
+  <script type="module" src="/assets/auth.js"></script>
+  <script src="/assets/main.js" defer></script>
 </body>
 </html>

--- a/use-cases/screenplay.html
+++ b/use-cases/screenplay.html
@@ -31,7 +31,7 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </header>
 
@@ -80,6 +80,7 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
   </div>
 </footer>
-<script src="/assets/main.js"></script>
+<script type="module" src="/assets/auth.js"></script>
+<script src="/assets/main.js" defer></script>
 </body>
 </html>

--- a/use-cases/set-design.html
+++ b/use-cases/set-design.html
@@ -31,7 +31,7 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="/account.html">Sign up / Log in</a>
+    <button class="menu__cta" type="button" data-open-auth="signup" aria-haspopup="dialog">Sign up / Log in</button>
   </nav>
 </header>
 
@@ -78,6 +78,7 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
   </div>
 </footer>
-<script src="/assets/main.js"></script>
+<script type="module" src="/assets/auth.js"></script>
+<script src="/assets/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the standalone account page with a reusable Supabase-powered signup/login modal and automatically trigger it for legacy visitors
- wire the navigation CTAs across the site to open the popup, update button styling, and document the new workflow and membership best practices
- add dedicated styling and scripting for the modal, including accessible focus management and session-aware labels

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc2dface00832d95f831d9d15b16b8