### PR TITLE
Clarify signup messaging when Supabase blocks new accounts

### DIFF
--- a/account.html
+++ b/account.html
@@ -47,6 +47,7 @@
       <button class="btn btn-ghost" type="button" data-open-auth="login" data-auth-no-redirect="true">Log in</button>
       <a class="btn btn-ghost" href="mailto:support@studioorganize.com?subject=StudioOrganize%20Account%20Help">Need help?</a>
     </div>
+    <p class="muted" style="margin-top:12px">Seeing a message that sign-ups are disabled? Drop us a line at <a href="mailto:support@studioorganize.com?subject=StudioOrganize%20Account%20Help">support@studioorganize.com</a> and we’ll activate your account manually.</p>
     <p class="muted" style="margin-top:12px">Tip: once you’re signed in, bookmark <a href="https://app.studioorganize.com" target="_blank" rel="noopener">app.studioorganize.com</a> for quick access.</p>
   </div>
 </main>


### PR DESCRIPTION
## Summary
- add contextual error handling to the auth modal so Supabase blocking messages guide users to contact support
- note the manual activation process on the account help page to reduce confusion

## Testing
- n/a (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68dc3e5a54a0832da25b277746ac782f