### PR TITLE
Surface Supabase signup disable state in auth modal

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -77,6 +77,8 @@ img{max-width:100%;display:block}
 .auth-modal__header h2{margin:0;font-size:24px}
 .auth-modal__subtitle{margin:6px 0 0;color:var(--muted)}
 .auth-form{display:flex;flex-direction:column;gap:14px}
+.auth-form--signup-disabled{opacity:.7}
+.auth-form--signup-disabled .auth-form__submit{cursor:not-allowed}
 .auth-form[hidden]{display:none !important}
 .auth-form__field{display:flex;flex-direction:column;gap:6px}
 .auth-form__field label{font-weight:600;font-size:14px}


### PR DESCRIPTION
## Summary
- detect the Supabase auth configuration when the modal opens and surface a clear disabled message
- keep the signup form submit button inactive while registrations are turned off and report the state in diagnostics
- add light styling that reflects the disabled signup state in the modal UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddb48497c4832db2db643b308ed5e8