### PR TITLE
Fix auth CTA visibility when account menu is shown

### DIFF
--- a/supabase-test.html
+++ b/supabase-test.html
@@ -318,6 +318,19 @@
     const accountButton = document.querySelector('[data-account-button]');
     const accountLogoutLink = document.querySelector('[data-account-logout]');
 
+    function toggleElementVisibility(element, shouldShow) {
+      if (!element) return;
+      if (shouldShow) {
+        element.hidden = false;
+        element.removeAttribute('aria-hidden');
+        element.style.display = '';
+      } else {
+        element.hidden = true;
+        element.setAttribute('aria-hidden', 'true');
+        element.style.display = 'none';
+      }
+    }
+
     const state = {
       session: null
     };
@@ -360,12 +373,8 @@
         const email = newSession.user?.email || 'Unknown user';
         sessionDetails.textContent = `User: ${email}`;
         setAuthDependentState(true);
-        if (authLink) {
-          authLink.hidden = true;
-        }
-        if (accountMenu) {
-          accountMenu.hidden = false;
-        }
+        toggleElementVisibility(authLink, false);
+        toggleElementVisibility(accountMenu, true);
         if (accountButton) {
           accountButton.textContent = 'Account';
         }
@@ -374,12 +383,8 @@
         sessionIndicator.textContent = 'Signed out';
         sessionDetails.textContent = 'No active session';
         setAuthDependentState(false);
-        if (authLink) {
-          authLink.hidden = false;
-        }
-        if (accountMenu) {
-          accountMenu.hidden = true;
-        }
+        toggleElementVisibility(authLink, true);
+        toggleElementVisibility(accountMenu, false);
         if (accountButton) {
           accountButton.textContent = 'Account';
         }


### PR DESCRIPTION
## Summary
- ensure the navigation "Sign up / Log in" CTA hides when a session is active
- reuse a helper to toggle the auth CTA and account dropdown visibility consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dedd21d058832da7faacf0b8049646