### PR TITLE
Add shared Supabase nav session handling

### DIFF
--- a/about.html
+++ b/about.html
@@ -33,7 +33,15 @@
     <a class="menu__link is-active" href="/about.html">About</a>
     <a class="menu__link" href="mailto:hello@studioorganize.com">Contact</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </div></header>
 <main class="container">
@@ -43,5 +51,5 @@
 </main>
 <footer class="footer"><div class="container">© <span id="y"></span> StudioOrganize</div></footer>
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
-<script src="assets/main.js" defer></script>
+<script type="module" src="assets/main.js"></script>
 </body></html>

--- a/account.html
+++ b/account.html
@@ -32,7 +32,15 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </header>
 
@@ -61,6 +69,6 @@
 </footer>
 
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
-<script src="/assets/main.js" defer></script>
+<script type="module" src="/assets/main.js"></script>
 </body>
 </html>

--- a/auth/callback/index.html
+++ b/auth/callback/index.html
@@ -33,7 +33,15 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </header>
 
@@ -64,7 +72,7 @@
 </footer>
 
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
-<script src="/assets/main.js" defer></script>
+  <script type="module" src="/assets/main.js"></script>
 <script>
   (function(){
     const creativeHubUrl = '/creative-hub.html';

--- a/creative-hub.html
+++ b/creative-hub.html
@@ -34,7 +34,15 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </header>
 
@@ -100,6 +108,6 @@
 </footer>
 
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
-<script src="/assets/main.js" defer></script>
+<script type="module" src="/assets/main.js"></script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -33,7 +33,15 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="mailto:hello@studioorganize.com">Contact</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </div></header>
 <main class="container">
@@ -47,5 +55,5 @@
 </main>
 <footer class="footer"><div class="container">© <span id="y"></span> StudioOrganize</div></footer>
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
-<script src="assets/main.js" defer></script>
+<script type="module" src="assets/main.js"></script>
 </body></html>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,15 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </header>
 
@@ -188,6 +196,6 @@
   </div>
 </footer>
 
-<script src="/assets/main.js" defer></script>
+<script type="module" src="/assets/main.js"></script>
 </body>
 </html>

--- a/product/1week-story
+++ b/product/1week-story
@@ -32,7 +32,15 @@
 
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </header>
 
@@ -93,6 +101,6 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
   </div>
 </footer>
-<script src="/assets/main.js" defer></script>
+<script type="module" src="/assets/main.js"></script>
 </body>
 </html>

--- a/product/personal.html
+++ b/product/personal.html
@@ -31,7 +31,15 @@
     </div>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </header>
 
@@ -73,6 +81,6 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a></div>
   </div>
 </footer>
-<script src="/assets/main.js" defer></script>
+<script type="module" src="/assets/main.js"></script>
 </body>
 </html>

--- a/product/studioorganize.html
+++ b/product/studioorganize.html
@@ -33,7 +33,15 @@
 
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </header>
 
@@ -113,6 +121,6 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
   </div>
 </footer>
-<script src="/assets/main.js" defer></script>
+<script type="module" src="/assets/main.js"></script>
 </body>
 </html>

--- a/product/template.html
+++ b/product/template.html
@@ -35,7 +35,15 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="mailto:hello@studioorganize.com">Contact</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </div></header>
 
@@ -78,5 +86,5 @@
 
 <footer class="footer"><div class="container">© <span id="y"></span> StudioOrganize</div></footer>
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
-<script src="../assets/main.js" defer></script>
+<script type="module" src="../assets/main.js"></script>
 </body></html>

--- a/products/index.html
+++ b/products/index.html
@@ -35,7 +35,15 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </header>
 
@@ -90,6 +98,6 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a></div>
   </div>
 </footer>
-<script src="/assets/main.js" defer></script>
+<script type="module" src="/assets/main.js"></script>
 </body>
 </html>

--- a/products/personal.html
+++ b/products/personal.html
@@ -33,7 +33,15 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="mailto:hello@studioorganize.com">Contact</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </div></header>
 
@@ -54,5 +62,5 @@
 
 <footer class="footer"><div class="container">© <span id="y"></span> StudioOrganize</div></footer>
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
-<script src="../assets/main.js" defer></script>
+<script type="module" src="../assets/main.js"></script>
 </body></html>

--- a/supabase-test.html
+++ b/supabase-test.html
@@ -297,7 +297,7 @@
     </section>
   </main>
 
-  <script src="/assets/main.js" defer></script>
+  <script type="module" src="/assets/main.js"></script>
 
   <script type="module">
     import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';

--- a/use-cases/character-design.html
+++ b/use-cases/character-design.html
@@ -32,7 +32,15 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </header>
 
@@ -79,6 +87,6 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
   </div>
 </footer>
-<script src="/assets/main.js" defer></script>
+<script type="module" src="/assets/main.js"></script>
 </body>
 </html>

--- a/use-cases/generate-ideas.html
+++ b/use-cases/generate-ideas.html
@@ -33,7 +33,15 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </header>
 
@@ -99,6 +107,6 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
   </div>
 </footer>
-<script src="/assets/main.js" defer></script>
+<script type="module" src="/assets/main.js"></script>
 </body>
 </html>

--- a/use-cases/index.html
+++ b/use-cases/index.html
@@ -33,7 +33,15 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </header>
 
@@ -76,6 +84,6 @@
   </div>
 </footer>
 
-<script src="/assets/main.js" defer></script>
+<script type="module" src="/assets/main.js"></script>
 </body>
 </html>

--- a/use-cases/screenplay-writing.html
+++ b/use-cases/screenplay-writing.html
@@ -35,7 +35,15 @@
       <a class="menu__link" href="/about.html">About</a>
       <a class="menu__link" href="/faq.html">FAQ</a>
       <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+      <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+      <div class="dropdown" data-account-menu hidden>
+        <button class="menu__cta" type="button" data-account-button>Account</button>
+        <div class="dropdown-content">
+          <a href="/account.html">My Creator Page</a>
+          <a href="/product/personal.html">My Subscription</a>
+          <a href="#" data-account-logout>Log out</a>
+        </div>
+      </div>
     </div>
     </nav>
   </header>
@@ -2272,6 +2280,6 @@
       <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
     </div>
   </footer>
-  <script src="/assets/main.js" defer></script>
+  <script type="module" src="/assets/main.js"></script>
 </body>
 </html>

--- a/use-cases/screenplay.html
+++ b/use-cases/screenplay.html
@@ -32,7 +32,15 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </header>
 
@@ -81,6 +89,6 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
   </div>
 </footer>
-<script src="/assets/main.js" defer></script>
+<script type="module" src="/assets/main.js"></script>
 </body>
 </html>

--- a/use-cases/set-design.html
+++ b/use-cases/set-design.html
@@ -32,7 +32,15 @@
     <a class="menu__link" href="/about.html">About</a>
     <a class="menu__link" href="/faq.html">FAQ</a>
     <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Toggle theme</button>
-    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html">Sign up / Log in</a>
+    <a class="menu__cta" href="https://studioorganize.com/supabase-test.html" data-auth-link>Sign up / Log in</a>
+    <div class="dropdown" data-account-menu hidden>
+      <button class="menu__cta" type="button" data-account-button>Account</button>
+      <div class="dropdown-content">
+        <a href="/account.html">My Creator Page</a>
+        <a href="/product/personal.html">My Subscription</a>
+        <a href="#" data-account-logout>Log out</a>
+      </div>
+    </div>
   </nav>
 </header>
 
@@ -79,6 +87,6 @@
     <div><a href="mailto:support@studioorganize.com">support@studioorganize.com</a><br/><span class="muted">© <span id="y"></span> StudioOrganize</span></div>
   </div>
 </footer>
-<script src="/assets/main.js" defer></script>
+<script type="module" src="/assets/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- import and initialize the Supabase client in `assets/main.js` so the global navigation reflects the active session
- update every top-level navigation bar to include the signed-in account dropdown and load the module version of the shared script
- keep the Supabase tester page aligned with the shared navigation logic

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dee637f25c832d9a738ff472b42b66