### PR TITLE
Fix storyboard fetch for scene saving

### DIFF
--- a/use-cases/screenplay-writing.html
+++ b/use-cases/screenplay-writing.html
@@ -3100,7 +3100,7 @@
           try {
             const { data: storyboardData, error: storyboardFetchError } = await supabase
               .from('scene_storyboards')
-              .select('id, image_url, position, url')
+              .select('id, image_url, position')
               .eq('owner_id', ownerId)
               .eq('scene_id', row.id)
               .order('position', { ascending: true });


### PR DESCRIPTION
## Summary
- remove the unused `url` column from scene storyboard fetches so Supabase queries only request existing fields
- prevent scene save failures caused by selecting a non-existent column on the `scene_storyboards` table

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e000dc5d40832dadd2ddb6d426cb12