### PR TITLE
Refine milestones planner layout

### DIFF
--- a/account.html
+++ b/account.html
@@ -237,35 +237,51 @@
         <p class="muted">Share your progress with collaborators for extra accountability.</p>
       </div>
 
-      <div class="insight-card">
+      <div class="insight-card insight-card--full">
         <div class="insight-card__header">
           <h3>Milestones &amp; Reminders</h3>
           <span class="insight-card__tag">Stay accountable</span>
         </div>
-        <form class="goal-form">
-          <label class="goal-form__field">
-            <span>Goal title</span>
-            <input type="text" name="goal" placeholder="Finish storyboard draft" />
-          </label>
-          <label class="goal-form__field">
-            <span>Target date</span>
-            <input type="date" name="deadline" />
-          </label>
-          <label class="goal-form__field">
-            <span>Email reminders</span>
-            <select name="reminder">
-              <option value="weekly">Weekly digest</option>
-              <option value="three-days">3 days before</option>
-              <option value="day-before">Day before deadline</option>
-              <option value="off">No reminders</option>
-            </select>
-          </label>
-          <label class="goal-form__field">
-            <span>Add a note (optional)</span>
-            <textarea name="note" rows="3" placeholder="Share progress with the team…"></textarea>
-          </label>
-          <button class="goal-form__submit" type="submit">Save goal</button>
-        </form>
+        <div class="goal-planner">
+          <aside class="goal-planner__form-panel" aria-label="Add a milestone goal">
+            <h4 class="goal-planner__heading">Plan a new milestone</h4>
+            <p class="goal-planner__copy">Set a focus target, pick when it is due, and choose how you would like to be nudged.</p>
+            <form class="goal-form" data-goal-form>
+              <label class="goal-form__field">
+                <span>Goal title</span>
+                <input type="text" name="goal" placeholder="Finish storyboard draft" />
+              </label>
+              <label class="goal-form__field">
+                <span>Target date</span>
+                <input type="date" name="deadline" />
+              </label>
+              <label class="goal-form__field">
+                <span>Email reminders</span>
+                <select name="reminder">
+                  <option value="weekly">Weekly digest</option>
+                  <option value="three-days">3 days before</option>
+                  <option value="day-before">Day before deadline</option>
+                  <option value="off">No reminders</option>
+                </select>
+              </label>
+              <label class="goal-form__field">
+                <span>Add a note (optional)</span>
+                <textarea name="note" rows="3" placeholder="Share progress with the team…"></textarea>
+              </label>
+              <button class="goal-form__submit" type="submit">Save goal</button>
+            </form>
+          </aside>
+          <section class="goal-planner__list-panel" aria-live="polite">
+            <div class="goal-list">
+              <header class="goal-list__header">
+                <h4>Saved goals</h4>
+                <p class="muted">Track multiple milestones and update them as you progress.</p>
+              </header>
+              <ol class="goal-list__items" data-goal-list></ol>
+              <p class="goal-list__empty" data-goal-empty hidden>You have not saved any goals yet.</p>
+            </div>
+          </section>
+        </div>
         <p class="muted goal-form__footnote">
           Reminders will be delivered to your StudioOrganize email contact. You can manage alerts in your account settings at any time.
         </p>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -165,6 +165,7 @@ img{max-width:100%;display:block}
 .creator-dashboard__intro p{max-width:640px}
 .creator-dashboard__grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:20px}
 .insight-card{background:var(--panel);border:1px solid var(--line);border-radius:18px;padding:22px;display:flex;flex-direction:column;gap:18px;box-shadow:0 18px 40px rgba(0,0,0,.18)}
+.insight-card--full{grid-column:1/-1}
 .insight-card__header{display:flex;justify-content:space-between;align-items:center;gap:14px}
 .insight-card__header h3{margin:0;font-size:20px}
 .insight-card__tag{font-size:12px;padding:4px 10px;border-radius:999px;background:var(--chip);color:var(--muted);border:1px solid var(--line)}
@@ -172,6 +173,25 @@ img{max-width:100%;display:block}
 .insight-card__stats div{background:var(--hud);border:1px solid var(--line);border-radius:14px;padding:14px;display:flex;flex-direction:column;gap:6px}
 .insight-card__stats dt{font-size:13px;color:var(--muted)}
 .insight-card__stats dd{margin:0;font-size:24px;font-weight:700;color:var(--ink)}
+.goal-list{display:flex;flex-direction:column;gap:16px;border-top:1px solid var(--line);padding-top:16px}
+.goal-list__header h4{margin:0;font-size:18px}
+.goal-list__items{display:flex;flex-direction:column;gap:12px;margin:0;padding:0;list-style:none}
+.goal-list__item{display:grid;gap:8px;padding:14px;border:1px solid var(--line);border-radius:14px;background:var(--hud)}
+.goal-list__item-header{display:flex;flex-wrap:wrap;gap:8px;justify-content:space-between;align-items:center}
+.goal-list__item-title{font-size:16px;font-weight:600;margin:0}
+.goal-list__item-meta{font-size:13px;color:var(--muted);display:flex;gap:12px;flex-wrap:wrap}
+.goal-list__item-note{margin:0;font-size:14px;line-height:1.5}
+.goal-list__actions{display:flex;justify-content:flex-end}
+.goal-list__remove{background:none;border:none;color:var(--muted);font-size:13px;cursor:pointer;padding:0;align-self:flex-start;text-decoration:underline}
+.goal-list__remove:hover{color:var(--ink)}
+.goal-list__empty{margin:0;font-size:14px;color:var(--muted)}
+.goal-planner{display:flex;flex-direction:column;gap:24px}
+.goal-planner__form-panel{display:flex;flex-direction:column;gap:16px;padding:22px;border:1px solid var(--line);border-radius:18px;background:var(--hud)}
+.goal-planner__heading{margin:0;font-size:18px}
+.goal-planner__copy{margin:0;font-size:14px;color:var(--muted)}
+.goal-planner__list-panel{display:flex;flex-direction:column;gap:16px}
+.goal-planner__list-panel .goal-list{border-top:none;padding-top:0}
+@media (min-width:900px){.goal-planner{flex-direction:row;align-items:flex-start}.goal-planner__form-panel{flex:0 0 320px}.goal-planner__list-panel{flex:1}}
 .commitment-grid{display:flex;flex-direction:column;gap:12px}
 .commitment-grid__row{display:grid;grid-template-columns:repeat(12,1fr);gap:6px;font-size:12px;color:var(--muted)}
 .commitment-grid__matrix{display:grid;grid-template-columns:repeat(12,1fr);gap:6px}


### PR DESCRIPTION
## Summary
- reorganize the Milestones & Reminders insight into a two-column planner with a dedicated goal form panel
- add supporting copy and responsive layout styles for the planner and saved goals list

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e13c80737c832db0aed78c2634a5ea