### PR TITLE
Fix PDF export popup handling

### DIFF
--- a/use-cases/screenplay-writing.html
+++ b/use-cases/screenplay-writing.html
@@ -5897,10 +5897,15 @@
 
     function printPDF(){
       const html = buildPrintableDocument();
-      const printWindow = window.open('', '_blank', 'noopener');
+      const printWindow = window.open('', '_blank');
       if (!printWindow){
         alert('Allow pop-ups to export your PDF.');
         return;
+      }
+      try {
+        printWindow.opener = null;
+      } catch (err) {
+        console.warn('Unable to clear opener on print window:', err);
       }
       printWindow.document.open();
       printWindow.document.write(html);


### PR DESCRIPTION
## Summary
- adjust the PDF export logic to avoid using the noopener feature that prevented us from getting a window handle
- explicitly clear the opener reference after the window opens to maintain safety

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e13fa6f1fc832db1efd37141cdc7eb