### PR TITLE
Center creator app tiles with fixed width

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -134,18 +134,19 @@ img{max-width:100%;display:block}
 @media (max-width:940px){.grid.two{grid-template-columns:1fr}}
 
 /* account app grid */
-.app-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:20px}
-.app-card{background:var(--panel);border:1px solid var(--line);border-radius:16px;display:flex;flex-direction:column;overflow:hidden;text-decoration:none;color:var(--text);transition:transform .12s ease,border-color .12s ease}
-.app-card img{width:100%;height:160px;object-fit:cover}
-.app-card--fit img{object-fit:contain;padding:12px;background:var(--panel)}
-.app-card__label{font-weight:600;font-size:18px;padding:16px}
+.app-grid{display:grid;grid-template-columns:repeat(3,minmax(0,200px));gap:20px;justify-content:center;justify-items:center}
+.app-card{background:var(--panel);border:1px solid var(--line);border-radius:16px;display:grid;grid-template-rows:1fr auto;gap:12px;padding:16px;overflow:hidden;text-decoration:none;color:var(--text);transition:transform .12s ease,border-color .12s ease;aspect-ratio:1/1;align-items:center;justify-items:center;text-align:center;width:100%;max-width:200px}
+.app-card img{display:block;width:100%;height:100%;object-fit:cover;border-radius:12px}
+.app-card--fit img{object-fit:contain;background:var(--panel)}
+.app-card__label{font-weight:600;font-size:18px;align-self:stretch;padding:4px 8px}
 .app-card:hover{transform:translateY(-2px);border-color:#2b3140}
 .app-card:focus-visible{outline:2px solid var(--acc);outline-offset:3px}
 .app-card--placeholder{cursor:default;opacity:.75}
 .app-card--placeholder:hover{transform:none;border-color:var(--line)}
 .app-card--placeholder img{filter:saturate(.7)}
-@media (max-width:900px){.app-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
-@media (max-width:600px){.app-grid{grid-template-columns:1fr}}
+@media (max-width:900px){.app-grid{grid-template-columns:repeat(2,minmax(0,200px))}}
+@media (max-width:720px){.app-grid{gap:16px}}
+@media (max-width:600px){.app-grid{grid-template-columns:minmax(0,220px)}.app-card{max-width:220px}}
 
 /* creator dashboard */
 .creator-dashboard{margin-top:48px;display:flex;flex-direction:column;gap:32px}


### PR DESCRIPTION
## Summary
- center the creator app cards within the grid with fixed-width columns so each tile stays consistent
- tune responsive breakpoints so the cards remain evenly sized while allowing narrow screens to stack comfortably

## Testing
- not run (static CSS change)

------
https://chatgpt.com/codex/tasks/task_e_68e1406a3eb4832da049dd7303d16892