### PR TITLE
Fix writer tag labels stacking above script text

### DIFF
--- a/use-cases/screenplay-writing.html
+++ b/use-cases/screenplay-writing.html
@@ -146,6 +146,7 @@
         pointer-events:none;
         white-space:nowrap;
         box-shadow:0 6px 18px rgba(0,0,0,0.15);
+        z-index:2;
       }
       .line[data-story-part="intro"]{border-left:3px solid var(--acc); padding-left:12px}
       .line[data-story-part="beginning"]{border-left:3px solid #7c4dff; padding-left:12px}


### PR DESCRIPTION
## Summary
- ensure script tag labels in the screenplay writer display above the script lines by raising their stacking order

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e4fa771df4832d9b415165c6b3ead2